### PR TITLE
feat: add command clear

### DIFF
--- a/src/cli/run_command.rs
+++ b/src/cli/run_command.rs
@@ -7,6 +7,7 @@ pub fn run_command(cmd: &str, args: &[String]) -> Result<String, String> {
         "echo" => echo(args),
         "cp" => cp::cp(args),
         "exit" => process::exit(0),
+        "clear" => Ok("\x1b[H\x1b[2J\x1b[3J".into()),
         _ => Err(format!("Command '{}' not found", cmd)),
     }
 }


### PR DESCRIPTION
Add clear command by printing ANSI escape codes:

\x1b: Hex value of escape character prefix.
[H: Set the cursor position to the first line.
[2J: Clears entire screen.
[3J: delete all lines saved in the scrollback buffer.