### PR TITLE
fix: better error handling, and error format

### DIFF
--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -1,4 +1,6 @@
+use crate::utils::error::StrError;
 use std::fs;
+
 /// minimal implementation of cp utility according to [POSIX: cp](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cp.html)
 ///
 /// TODO: handle allowed options
@@ -18,43 +20,54 @@ pub fn cp(args: &[String]) -> i32 {
 
     // first synopsis:
     if args.len() == 2 {
-        return perform_copy(src, target);
+        let target_file = match fs::metadata(target) {
+            // second synopsis:
+            Ok(m) if m.is_dir() => &join_target_path(src, target),
+            _ => target,
+        };
+
+        return perform_copy(src, target_file);
     }
 
     // second synopsis:
     // target is not a directory or other errors
-    let target_meta = match fs::metadata(target) {
-        Ok(m) => m,
+    match fs::metadata(target) {
+        Ok(m) => {
+            if !m.is_dir() {
+                eprintln!("cp: target '{target}': Not a directory");
+                return 1;
+            }
+        }
         Err(e) => {
-            eprintln!("cp: '{target}' {e}");
+            eprintln!("cp: target '{target}': {}", e.str());
             return 1;
         }
     };
 
-    if !target_meta.is_dir() {
-        eprintln!("cp: target '{target}' is not a directory");
-        return 1;
-    }
-
     let src_files = &args[..args.len() - 1];
     let mut exit_status = 0;
-    for src in src_files {
-        // target_file is the destination path named by the concatenation of target,
-        // a single <slash> character if target did not end in a <slash>,
-        // and the last component of source_file.
 
-        let src_last = src.split("/").last().unwrap_or(&src);
-        let target_file = target.trim_end_matches("/").to_string() + "/" + src_last;
+    for src in src_files {
+        let target_file = join_target_path(src, target);
         exit_status += perform_copy(src, &target_file);
     }
 
     return if exit_status > 0 { 1 } else { 0 };
 }
 
+/// the destination path named by the concatenation of `target`,
+/// a single `/` character if `target` did not end in a `/`,
+/// and the last component of `source_file`.
+pub fn join_target_path(source_file: &str, target: &str) -> String {
+    let src_last = source_file.split("/").last().unwrap_or(&source_file);
+    let target_file = target.trim_end_matches("/").to_string() + "/" + src_last;
+    return target_file;
+}
+
 fn perform_copy(src: &str, target: &str) -> i32 {
     let src_meta = match fs::metadata(src) {
         Err(e) => {
-            eprintln!("cp: '{src}' {e}");
+            eprintln!("cp: cannot stat '{src}' {}", e.str());
             return 1;
         }
         Ok(m) => m,
@@ -65,8 +78,16 @@ fn perform_copy(src: &str, target: &str) -> i32 {
         return 1;
     }
 
-    if let Err(e) = fs::copy(src, &target) {
-        eprintln!("cp: '{src}' -> '{target}' {e}");
+    if let Ok(src_abs) = fs::canonicalize(src) {
+        if let Ok(target_abs) = fs::canonicalize(target) {
+            if src_abs == target_abs {
+                eprintln!("cp: '{src}' and '{target}' are the same file");
+                return 1;
+            }
+        }
+    }
+    if let Err(e) = fs::copy(src, target) {
+        eprintln!("cp: target '{target}': {}", e.str());
         return 1;
     }
 

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -1,6 +1,19 @@
-use std::ffi::CStr;
-
 use libc::c_int;
+use std::{ffi::CStr, io::Error};
+pub trait StrError {
+    fn str(&self) -> String;
+}
+
+impl StrError for Error {
+    fn str(&self) -> String {
+        return if let Some(errno) = self.raw_os_error() {
+            strerror(errno)
+        } else {
+            self.to_string()
+        };
+    }
+}
+
 pub fn strerror(errno: c_int) -> String {
     unsafe {
         let c_rawchar = libc::strerror(errno);


### PR DESCRIPTION
- Remove OS error suffix.
- Handle errors:
  - Case 1: `$ cp file dir` should copy the file instead of printing an error.
  - Case 2: `$ cp file file` should print an error instead of copying the file to itself, which truncates the file.